### PR TITLE
Bump EHRbase version to 2.9.0 and update dependencies

### DIFF
--- a/charts/ehrbase/Chart.lock
+++ b/charts/ehrbase/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.5.37
+  version: 15.5.38
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 20.1.5
-digest: sha256:e6a6edae54948aaf426cb72f0182f4c6c88d6ec9f9f275010d5993651cc60be2
-generated: "2024-10-01T19:38:47.8439874+02:00"
+  version: 20.1.7
+digest: sha256:8c24d17398f1f469b7438f7934c6494b368d0573194a8ad328825b0f31d3e75f
+generated: "2024-10-06T14:20:29.3589307+02:00"

--- a/charts/ehrbase/Chart.yaml
+++ b/charts/ehrbase/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ehrbase
-version: 0.6.0
+version: 0.7.0
 kubeVersion: ">=1.26"
 description: EHRbase is an open source software backend for clinical application systems and electronic health records.
 type: application
@@ -23,4 +23,4 @@ dependencies:
 maintainers:
   - name: Konateq
     url: https://konateq.com
-appVersion: "2.8.1"
+appVersion: "2.9.0"


### PR DESCRIPTION
### Changes

- Bump EHRbase version to 2.9.0
- Update dependencies
- Bump chart version to 0.7.0